### PR TITLE
Bypass cache when the tab reloads

### DIFF
--- a/background.js
+++ b/background.js
@@ -60,7 +60,7 @@ browser.pageAction.onClicked.addListener(function(tab) {
         let to_store = {}
         to_store[host] = !whitelist_js
         browser.storage.local.set(to_store).then( function() {
-            browser.tabs.reload()
+            browser.tabs.reload({bypassCache: true})
         })
     })
 })


### PR DESCRIPTION
New setting won't take effect if the browser is using a cached version of the response headers